### PR TITLE
depth is decreased too much when limit is reached

### DIFF
--- a/vcat-core/src/main/java/vcat/AbstractVCat.java
+++ b/vcat-core/src/main/java/vcat/AbstractVCat.java
@@ -171,7 +171,7 @@ public abstract class AbstractVCat<W extends IWiki> {
 						categoryNamespacePrefixLength, showhidden, exceedDepth);
 
 				if (limit != null && graph.getNodeCount() > limit && curDepth > 1) {
-					return renderGraphForDepth(curDepth - 1);
+					return renderGraphForDepth(curDepth);
 				}
 			}
 


### PR DESCRIPTION
As reported in issue #145, the depth is reduced too much when the limit
for the number of nodes is exceeded.