### PR TITLE
Security: Stop possible server-side request forgery

### DIFF
--- a/vcat-core/src/main/java/org/toolforge/vcat/mediawiki/SimpleWikimediaWiki.java
+++ b/vcat-core/src/main/java/org/toolforge/vcat/mediawiki/SimpleWikimediaWiki.java
@@ -1,8 +1,10 @@
 package org.toolforge.vcat.mediawiki;
 
+import jakarta.ws.rs.core.UriBuilder;
 import org.toolforge.vcat.mediawiki.interfaces.Wiki;
 
 import java.io.Serial;
+import java.net.URI;
 
 public class SimpleWikimediaWiki implements Wiki {
 
@@ -17,7 +19,9 @@ public class SimpleWikimediaWiki implements Wiki {
 
     @Override
     public String getApiUrl() {
-        return "https://" + host + "/w/api.php";
+        // Security: use an UriBuilder to escape the host name
+        final var uri = URI.create("https://HOST/w/api.php");
+        return UriBuilder.fromUri(uri).host(host).toString();
     }
 
     @Override

--- a/vcat-core/src/test/java/org/toolforge/vcat/mediawiki/SimpleWikimediaWikiTest.java
+++ b/vcat-core/src/test/java/org/toolforge/vcat/mediawiki/SimpleWikimediaWikiTest.java
@@ -1,0 +1,23 @@
+package org.toolforge.vcat.mediawiki;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class SimpleWikimediaWikiTest {
+
+    @ParameterizedTest
+    @CsvSource(textBlock = """
+            en.wikipedia.org, https://en.wikipedia.org/w/api.php
+            127.0.0.1, https://127.0.0.1/w/api.php
+            [::1], https://[::1]/w/api.php
+            will?be#escaped, https://will%3Fbe%23escaped/w/api.php
+            """)
+    void getApiUrl(String host, String expectedApiUrl) {
+        final var wiki = new SimpleWikimediaWiki(host);
+        final var apiUrl = wiki.getApiUrl();
+        assertEquals(expectedApiUrl, apiUrl);
+    }
+
+}


### PR DESCRIPTION
Sanitize the API URL by using a UriBuilder to set its host name.