### PR TITLE
Replace storage for ReentrantLocks by new class

### DIFF
--- a/vcat-core/src/main/java/org/toolforge/vcat/util/ReentrantLocks.java
+++ b/vcat-core/src/main/java/org/toolforge/vcat/util/ReentrantLocks.java
@@ -1,0 +1,91 @@
+package org.toolforge.vcat.util;
+
+import java.lang.ref.ReferenceQueue;
+import java.lang.ref.WeakReference;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+
+/**
+ * Key-based locking based on {@link ReentrantLock}.
+ *
+ * @param <K> type of key
+ */
+public class ReentrantLocks<K> {
+
+    private class LockReference extends WeakReference<ReentrantLock> {
+
+        private final K key;
+
+        private LockReference(K key, ReentrantLock lock) {
+            super(lock, lockReferenceQueue);
+            this.key = key;
+        }
+
+        private K getKey() {
+            return key;
+        }
+
+    }
+
+    private final Map<K, LockReference> lockReferenceMap = new ConcurrentHashMap<>();
+
+    private final ReferenceQueue<ReentrantLock> lockReferenceQueue = new ReferenceQueue<>();
+
+    private final Lock lockReferenceQueueLock = new ReentrantLock();
+
+    /**
+     * Return a lock already locked using {@link Lock#lock()}.
+     *
+     * @param key key
+     * @return already locked lock
+     */
+    public ReentrantLock lock(K key) {
+        processQueue();
+        final var lock = Objects.requireNonNull(
+                newLock(key)
+        );
+        lock.lock();
+        return lock;
+    }
+
+    /**
+     * Returns the current number of locks managed by this instance.
+     *
+     * @return number of locks
+     */
+    public int size() {
+        processQueue();
+        return lockReferenceMap.size();
+    }
+
+    private ReentrantLock newLock(K key) {
+        return Objects.requireNonNull(
+                lockReferenceMap.computeIfAbsent(key, this::newLockReference).get()
+        );
+    }
+
+    private LockReference newLockReference(K key) {
+        final var lock = new ReentrantLock();
+        return new LockReference(key, lock);
+    }
+
+    /**
+     * Removes all locks that have been marked as unreachable by the garbage collector.
+     */
+    @SuppressWarnings("unchecked")
+    private void processQueue() {
+        lockReferenceQueueLock.lock();
+        try {
+            LockReference lockReference;
+            while ((lockReference = (LockReference) lockReferenceQueue.poll()) != null) {
+                lockReferenceMap.remove(lockReference.getKey());
+            }
+        } finally {
+            lockReferenceQueueLock.unlock();
+        }
+    }
+
+}

--- a/vcat-core/src/test/java/org/toolforge/vcat/util/ReentrantLocksTest.java
+++ b/vcat-core/src/test/java/org/toolforge/vcat/util/ReentrantLocksTest.java
@@ -1,0 +1,71 @@
+package org.toolforge.vcat.util;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReentrantLocksTest {
+
+    @Test
+    void testLocking() throws Exception {
+        final ReentrantLocks<Integer> locks = new ReentrantLocks<>();
+
+        AtomicBoolean threadHasStarted = new AtomicBoolean(false);
+        AtomicBoolean threadHasLocked = new AtomicBoolean(false);
+
+        var lock = locks.lock(1);
+        try {
+
+            Runnable runnable = () -> {
+                threadHasStarted.set(true);
+                var l = locks.lock(1);
+                try {
+                    threadHasLocked.set(true);
+                } finally {
+                    l.unlock();
+                }
+            };
+            new Thread(runnable).start();
+
+            while (!threadHasStarted.get()) {
+                Thread.yield();
+            }
+
+            TimeUnit.SECONDS.sleep(1);
+
+            assertFalse(threadHasLocked.get());
+
+        } finally {
+            lock.unlock();
+        }
+
+        TimeUnit.SECONDS.sleep(1);
+
+        assertTrue(threadHasLocked.get());
+    }
+
+    @Test
+    void testLocksAreReleasedWhenUnused() throws Exception {
+        final ReentrantLocks<Integer> locks = new ReentrantLocks<>();
+
+        var lock = locks.lock(1);
+        lock.unlock();
+
+        int size = locks.size();
+        assertEquals(1, size);
+
+        // wait up to 30 seconds for size to change after dereferencing the lock
+        lock = null;
+        for (int i = 30; i > 0 && size > 0; i--) {
+            // purely for encouragement, not guaranteed to do anything
+            System.gc();
+            TimeUnit.SECONDS.sleep(1);
+            size = locks.size();
+        }
+        assertEquals(0, size);
+    }
+
+}


### PR DESCRIPTION
A WeakHashMap is not the correct way to get locks with a key; it requires some implementation of a WeakValueHashMap. The new ReentrantLocks class is a more specialized alternative to this.